### PR TITLE
feat(history): implement status history tracking with service layer

### DIFF
--- a/backend/src/main/java/com/servicehub/controller/ServiceRequestController.java
+++ b/backend/src/main/java/com/servicehub/controller/ServiceRequestController.java
@@ -5,10 +5,13 @@ import com.servicehub.dto.request.CreateServiceRequestDto;
 import com.servicehub.dto.request.StatusUpdateRequest;
 import com.servicehub.dto.request.TransferRequest;
 import com.servicehub.exception.ResourceNotFoundException;
+import com.servicehub.model.User;
 import com.servicehub.model.enums.RequestStatus;
+import com.servicehub.model.enums.Role;
 import com.servicehub.repository.UserRepository;
 import com.servicehub.service.RequestWorkflowService;
 import com.servicehub.service.ServiceRequestService;
+import com.servicehub.service.StatusHistoryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -27,6 +30,7 @@ public class ServiceRequestController {
 
     private final ServiceRequestService serviceRequestService;
     private final RequestWorkflowService requestWorkflowService;
+    private final StatusHistoryService statusHistoryService;
     private final UserRepository userRepository;
 
     @GetMapping
@@ -74,7 +78,8 @@ public class ServiceRequestController {
 
     @GetMapping("/{id}/history")
     public ResponseEntity<?> getRequestHistory(@PathVariable Long id) {
-        return ResponseEntity.ok(serviceRequestService.getRequestHistory(id));
+        User currentUser = getCurrentUser();
+        return ResponseEntity.ok(statusHistoryService.getHistoryByRequestId(id, currentUser.getId(), currentUser.getRole()));
     }
 
     private UUID resolveCurrentUserId() {
@@ -82,5 +87,11 @@ public class ServiceRequestController {
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new ResourceNotFoundException("User", "email", email))
                 .getId();
+    }
+
+    private User getCurrentUser() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("User", "email", email));
     }
 }

--- a/backend/src/main/java/com/servicehub/dto/response/StatusHistoryResponse.java
+++ b/backend/src/main/java/com/servicehub/dto/response/StatusHistoryResponse.java
@@ -1,26 +1,22 @@
 package com.servicehub.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class StatusHistoryResponse {
-
-    private Long id;
-    private String fromStatus;
-    private String toStatus;
-    private String changedByName;
-    private UUID changedById;
-    private String fromAgentName;
-    private String toAgentName;
-    private String comment;
-    private LocalDateTime changedAt;
-}
+/**
+ * Response DTO for status history records.
+ * Uses Java Record for immutability and conciseness.
+ * Formats data cleanly for frontend consumption with string representations
+ * of statuses, user names, and timestamps.
+ */
+public record StatusHistoryResponse(
+        Long id,
+        String fromStatus,
+        String toStatus,
+        String changedByName,
+        UUID changedById,
+        String fromAgentName,
+        String toAgentName,
+        String comment,
+        LocalDateTime changedAt
+) {}

--- a/backend/src/main/java/com/servicehub/repository/StatusHistoryRepository.java
+++ b/backend/src/main/java/com/servicehub/repository/StatusHistoryRepository.java
@@ -8,5 +8,20 @@ import java.util.List;
 
 @Repository
 public interface StatusHistoryRepository extends JpaRepository<StatusHistory, Long> {
+    /**
+     * Finds all status history records for a given request, ordered by changed_at descending (most recent first).
+     *
+     * @param requestId the ID of the service request
+     * @return list of status history records, most recent first
+     */
+    List<StatusHistory> findByRequestIdOrderByChangedAtDesc(Long requestId);
+    
+    /**
+     * Finds all status history records for a given request, ordered by changed_at ascending (oldest first).
+     * Kept for backward compatibility.
+     *
+     * @param requestId the ID of the service request
+     * @return list of status history records, oldest first
+     */
     List<StatusHistory> findByRequestIdOrderByChangedAtAsc(Long requestId);
 }

--- a/backend/src/main/java/com/servicehub/service/RequestWorkflowService.java
+++ b/backend/src/main/java/com/servicehub/service/RequestWorkflowService.java
@@ -8,7 +8,6 @@ import com.servicehub.model.User;
 import com.servicehub.model.enums.RequestStatus;
 import com.servicehub.model.enums.Role;
 import com.servicehub.repository.ServiceRequestRepository;
-import com.servicehub.repository.StatusHistoryRepository;
 import com.servicehub.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,7 +29,7 @@ import java.util.UUID;
 public class RequestWorkflowService {
 
     private final ServiceRequestRepository serviceRequestRepository;
-    private final StatusHistoryRepository statusHistoryRepository;
+    private final StatusHistoryService statusHistoryService;
     private final UserRepository userRepository;
     private final StatusTransitionValidator statusTransitionValidator;
 
@@ -81,15 +80,14 @@ public class RequestWorkflowService {
         // Save the updated request
         ServiceRequest savedRequest = serviceRequestRepository.save(request);
 
-        // Create status history entry
-        StatusHistory statusHistory = StatusHistory.builder()
-                .request(savedRequest)
-                .fromStatus(previousStatus)
-                .toStatus(newStatus.name())
-                .changedBy(currentUser)
-                .comment(comment)
-                .build();
-        StatusHistory savedHistory = statusHistoryRepository.save(statusHistory);
+        // Record status change in history using StatusHistoryService
+        StatusHistory savedHistory = statusHistoryService.recordStatusChange(
+                savedRequest,
+                currentStatus,
+                newStatus,
+                currentUser,
+                comment
+        );
 
         log.info("Status updated: Request {} transitioned from {} to {} by {} ({})",
                 savedRequest.getReferenceNumber(), previousStatus, newStatus, currentUser.getFullName(), userRole);

--- a/backend/src/main/java/com/servicehub/service/ServiceRequestService.java
+++ b/backend/src/main/java/com/servicehub/service/ServiceRequestService.java
@@ -42,6 +42,7 @@ public class ServiceRequestService {
     private final UserRepository userRepository;
     private final SlaPolicyRepository slaPolicyRepository;
     private final StatusHistoryRepository statusHistoryRepository;
+    private final StatusHistoryService statusHistoryService;
     private final LocationRepository locationRepository;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -260,24 +261,14 @@ public class ServiceRequestService {
         serviceRequest.setAssignedAgent(targetAgent);
 
         // If status was IN_PROGRESS, revert to ASSIGNED
-        String fromStatus = serviceRequest.getStatus().name();
         if (serviceRequest.getStatus() == RequestStatus.IN_PROGRESS) {
             serviceRequest.setStatus(RequestStatus.ASSIGNED);
         }
 
-        // Create status history with transfer details
-        StatusHistory history = StatusHistory.builder()
-                .request(serviceRequest)
-                .fromStatus(fromStatus)
-                .toStatus(serviceRequest.getStatus().name())
-                .changedBy(actor)
-                .fromAgent(previousAgent)
-                .toAgent(targetAgent)
-                .comment(request.getReason())
-                .build();
-        statusHistoryRepository.save(history);
-
         serviceRequest = serviceRequestRepository.save(serviceRequest);
+
+        // Record transfer in status history using StatusHistoryService
+        statusHistoryService.recordTransfer(serviceRequest, previousAgent, targetAgent, actor, request.getReason());
         log.info("Service request {} transferred from {} to {}",
                 serviceRequest.getReferenceNumber(),
                 previousAgent != null ? previousAgent.getFullName() : "none",

--- a/backend/src/main/java/com/servicehub/service/StatusHistoryService.java
+++ b/backend/src/main/java/com/servicehub/service/StatusHistoryService.java
@@ -1,0 +1,176 @@
+package com.servicehub.service;
+
+import com.servicehub.dto.response.StatusHistoryResponse;
+import com.servicehub.exception.BadRequestException;
+import com.servicehub.exception.ResourceNotFoundException;
+import com.servicehub.model.ServiceRequest;
+import com.servicehub.model.StatusHistory;
+import com.servicehub.model.User;
+import com.servicehub.model.enums.RequestStatus;
+import com.servicehub.repository.ServiceRequestRepository;
+import com.servicehub.repository.StatusHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Service for managing status history tracking and retrieval.
+ * Handles recording status changes and transfers with proper audit trail.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StatusHistoryService {
+
+    private final StatusHistoryRepository statusHistoryRepository;
+    private final ServiceRequestRepository serviceRequestRepository;
+
+    /**
+     * Records a standard status change transition.
+     * Creates a status history entry for workflow transitions.
+     *
+     * @param request   the service request being updated
+     * @param from      the previous status (can be null for initial creation)
+     * @param to        the new status (required)
+     * @param changedBy the user who triggered the status change
+     * @param comment   optional comment describing the change
+     * @return the saved StatusHistory entity
+     */
+    @Transactional
+    public StatusHistory recordStatusChange(
+            ServiceRequest request,
+            RequestStatus from,
+            RequestStatus to,
+            User changedBy,
+            String comment) {
+
+        StatusHistory statusHistory = StatusHistory.builder()
+                .request(request)
+                .fromStatus(from != null ? from.name() : null)
+                .toStatus(to.name())
+                .changedBy(changedBy)
+                .comment(comment)
+                .build();
+
+        StatusHistory saved = statusHistoryRepository.save(statusHistory);
+
+        log.debug("Status change recorded: Request {} transitioned from {} to {} by {}",
+                request.getReferenceNumber(),
+                from != null ? from.name() : "null",
+                to.name(),
+                changedBy.getFullName());
+
+        return saved;
+    }
+
+    /**
+     * Records a ticket transfer between agents.
+     * Ensures the comment (reason) is provided and saved.
+     * Sets both fromAgent and toAgent for transfer tracking.
+     *
+     * @param request   the service request being transferred
+     * @param fromAgent the agent who is transferring the ticket (can be null)
+     * @param toAgent   the agent receiving the ticket (required)
+     * @param changedBy the user who initiated the transfer
+     * @param reason    the reason for the transfer (required)
+     * @return the saved StatusHistory entity
+     * @throws BadRequestException if reason is null or empty
+     */
+    @Transactional
+    public StatusHistory recordTransfer(
+            ServiceRequest request,
+            User fromAgent,
+            User toAgent,
+            User changedBy,
+            String reason) {
+
+        if (reason == null || reason.trim().isEmpty()) {
+            throw new BadRequestException("Transfer reason is required");
+        }
+
+        // Determine the status transition
+        RequestStatus fromStatus = request.getStatus();
+        RequestStatus toStatus = fromStatus == RequestStatus.IN_PROGRESS
+                ? RequestStatus.ASSIGNED  // Revert to ASSIGNED if was IN_PROGRESS
+                : RequestStatus.ASSIGNED; // Stay ASSIGNED if already ASSIGNED
+
+        StatusHistory statusHistory = StatusHistory.builder()
+                .request(request)
+                .fromStatus(fromStatus.name())
+                .toStatus(toStatus.name())
+                .changedBy(changedBy)
+                .fromAgent(fromAgent)
+                .toAgent(toAgent)
+                .comment(reason)
+                .build();
+
+        StatusHistory saved = statusHistoryRepository.save(statusHistory);
+
+        log.info("Transfer recorded: Request {} transferred from {} to {} by {}",
+                request.getReferenceNumber(),
+                fromAgent != null ? fromAgent.getFullName() : "none",
+                toAgent.getFullName(),
+                changedBy.getFullName());
+
+        return saved;
+    }
+
+    /**
+     * Retrieves the complete status history timeline for a service request.
+     * Returns records ordered by changed_at descending (most recent first).
+     * Authorization: Owner, Assigned Agent, or ADMIN can access.
+     *
+     * @param requestId the ID of the service request
+     * @param currentUserId the ID of the currently authenticated user
+     * @param currentUserRole the role of the currently authenticated user
+     * @return list of StatusHistoryResponse DTOs, most recent first
+     * @throws ResourceNotFoundException if request not found
+     * @throws org.springframework.security.access.AccessDeniedException if user is not authorized
+     */
+    @Transactional(readOnly = true)
+    public List<StatusHistoryResponse> getHistoryByRequestId(Long requestId, java.util.UUID currentUserId, com.servicehub.model.enums.Role currentUserRole) {
+        // Fetch request and verify it exists
+        ServiceRequest request = serviceRequestRepository.findById(requestId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Service request not found with id: " + requestId));
+
+        // Authorization check: Owner, Assigned Agent, or ADMIN can access
+        boolean isOwner = request.getRequester() != null && request.getRequester().getId().equals(currentUserId);
+        boolean isAssignedAgent = request.getAssignedAgent() != null && request.getAssignedAgent().getId().equals(currentUserId);
+        boolean isAdmin = currentUserRole == com.servicehub.model.enums.Role.ADMIN;
+
+        if (!isOwner && !isAssignedAgent && !isAdmin) {
+            throw new org.springframework.security.access.AccessDeniedException(
+                    "Access denied: Only the request owner, assigned agent, or admin can view status history");
+        }
+
+        return statusHistoryRepository.findByRequestIdOrderByChangedAtDesc(requestId).stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Converts a StatusHistory entity to a StatusHistoryResponse DTO.
+     *
+     * @param history the StatusHistory entity
+     * @return StatusHistoryResponse DTO
+     */
+    private StatusHistoryResponse toResponse(StatusHistory history) {
+        return new StatusHistoryResponse(
+                history.getId(),
+                history.getFromStatus(),
+                history.getToStatus(),
+                history.getChangedBy() != null ? history.getChangedBy().getFullName() : null,
+                history.getChangedBy() != null ? history.getChangedBy().getId() : null,
+                history.getFromAgent() != null ? history.getFromAgent().getFullName() : null,
+                history.getToAgent() != null ? history.getToAgent().getFullName() : null,
+                history.getComment(),
+                history.getChangedAt()
+        );
+    }
+}
+


### PR DESCRIPTION
- Create StatusHistoryService with recordStatusChange and recordTransfer methods
- Update StatusHistoryRepository to support DESC ordering for timeline view
- Convert StatusHistoryResponse to Java Record for immutability
- Integrate StatusHistoryService into RequestWorkflowService
- Update ServiceRequestService to use StatusHistoryService for transfers
- Add authorization checks in StatusHistoryService (Owner, Assigned Agent, ADMIN)
- Update controller endpoint to use StatusHistoryService with proper authorization
- Ensure transfer reason is required and properly recorded