### PR TITLE
feat(sla): implement policy management and lookup logic

### DIFF
--- a/backend/src/main/java/com/servicehub/controller/SlaPolicyController.java
+++ b/backend/src/main/java/com/servicehub/controller/SlaPolicyController.java
@@ -1,6 +1,6 @@
 package com.servicehub.controller;
 
-import com.servicehub.dto.request.CreateSlaPolicyRequest;
+import com.servicehub.dto.request.SlaPolicyRequest;
 import com.servicehub.dto.request.UpdateSlaPolicyRequest;
 import com.servicehub.service.SlaPolicyService;
 import jakarta.validation.Valid;
@@ -10,29 +10,82 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * REST controller for SLA policy management.
+ * Provides CRUD operations for managing time-based SLA targets.
+ */
 @RestController
-@RequestMapping("/api/v1/admin/sla-policies")
+@RequestMapping("/api/v1/sla-policies")
 @RequiredArgsConstructor
 public class SlaPolicyController {
 
     private final SlaPolicyService slaPolicyService;
 
+    /**
+     * Retrieves all SLA policies.
+     * Accessible by any authenticated user.
+     *
+     * @return list of all SLA policies
+     */
     @GetMapping
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getAllPolicies() {
         return ResponseEntity.ok(slaPolicyService.getAllPolicies());
     }
 
-    @PostMapping
-    @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<?> createPolicy(@Valid @RequestBody CreateSlaPolicyRequest request) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(slaPolicyService.createPolicy(request));
+    /**
+     * Retrieves an SLA policy by ID.
+     * Accessible by any authenticated user.
+     *
+     * @param id the policy ID
+     * @return the SLA policy
+     */
+    @GetMapping("/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getPolicyById(@PathVariable Integer id) {
+        return ResponseEntity.ok(slaPolicyService.getPolicyById(id));
     }
 
+    /**
+     * Creates a new SLA policy.
+     * Only accessible by ADMIN users.
+     *
+     * @param request the policy creation request
+     * @return the created policy
+     */
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> createPolicy(@Valid @RequestBody SlaPolicyRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(slaPolicyService.createPolicy(request));
+    }
+
+    /**
+     * Updates an existing SLA policy.
+     * Only accessible by ADMIN users.
+     *
+     * @param id the policy ID
+     * @param request the update request
+     * @return the updated policy
+     */
     @PutMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<?> updatePolicy(@PathVariable Integer id,
                                           @Valid @RequestBody UpdateSlaPolicyRequest request) {
         return ResponseEntity.ok(slaPolicyService.updatePolicy(id, request));
+    }
+
+    /**
+     * Deletes an SLA policy.
+     * Only accessible by ADMIN users.
+     *
+     * @param id the policy ID
+     * @return no content response
+     */
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> deletePolicy(@PathVariable Integer id) {
+        slaPolicyService.deletePolicy(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/servicehub/dto/request/CreateSlaPolicyRequest.java
+++ b/backend/src/main/java/com/servicehub/dto/request/CreateSlaPolicyRequest.java
@@ -3,28 +3,23 @@ package com.servicehub.dto.request;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class CreateSlaPolicyRequest {
-
-    @NotNull(message = "Category ID is required")
-    private Long categoryId;
-
-    @NotBlank(message = "Priority is required")
-    private String priority;
-
-    @NotNull(message = "Response time is required")
-    @Min(value = 1, message = "Response time must be at least 1 minute")
-    private Integer responseTimeMinutes;
-
-    @NotNull(message = "Resolution time is required")
-    @Min(value = 1, message = "Resolution time must be at least 1 minute")
-    private Integer resolutionTimeMinutes;
-}
+/**
+ * Request DTO for creating an SLA policy.
+ * Uses Java Record for immutability and conciseness.
+ */
+public record SlaPolicyRequest(
+        @NotNull(message = "Category ID is required")
+        Long categoryId,
+        
+        @NotBlank(message = "Priority is required")
+        String priority,
+        
+        @NotNull(message = "Response time is required")
+        @Min(value = 1, message = "Response time must be at least 1 hour")
+        Integer responseTimeHours,
+        
+        @NotNull(message = "Resolution time is required")
+        @Min(value = 1, message = "Resolution time must be at least 1 hour")
+        Integer resolutionTimeHours
+) {}

--- a/backend/src/main/java/com/servicehub/dto/request/UpdateSlaPolicyRequest.java
+++ b/backend/src/main/java/com/servicehub/dto/request/UpdateSlaPolicyRequest.java
@@ -1,19 +1,18 @@
 package com.servicehub.dto.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.Min;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class UpdateSlaPolicyRequest {
-
-    private Integer responseTimeMinutes;
-
-    private Integer resolutionTimeMinutes;
-
-    private Boolean isActive;
-}
+/**
+ * Request DTO for updating an SLA policy.
+ * Uses Java Record for immutability and conciseness.
+ * All fields are optional for partial updates.
+ */
+public record UpdateSlaPolicyRequest(
+        @Min(value = 1, message = "Response time must be at least 1 hour")
+        Integer responseTimeHours,
+        
+        @Min(value = 1, message = "Resolution time must be at least 1 hour")
+        Integer resolutionTimeHours,
+        
+        Boolean isActive
+) {}

--- a/backend/src/main/java/com/servicehub/dto/response/SlaPolicyResponse.java
+++ b/backend/src/main/java/com/servicehub/dto/response/SlaPolicyResponse.java
@@ -1,21 +1,15 @@
 package com.servicehub.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class SlaPolicyResponse {
-
-    private Integer id;
-    private Long categoryId;
-    private String categoryName;
-    private String priority;
-    private Integer responseTimeMinutes;
-    private Integer resolutionTimeMinutes;
-    private Boolean isActive;
-}
+/**
+ * Response DTO for SLA policy operations.
+ * Uses Java Record for immutability and conciseness.
+ */
+public record SlaPolicyResponse(
+        Integer id,
+        Long categoryId,
+        String categoryName,
+        String priority,
+        Integer responseTimeHours,
+        Integer resolutionTimeHours,
+        Boolean isActive
+) {}

--- a/backend/src/main/java/com/servicehub/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/servicehub/exception/GlobalExceptionHandler.java
@@ -23,6 +23,12 @@ public class GlobalExceptionHandler {
         return buildResponse(HttpStatus.NOT_FOUND, "Not Found", ex.getMessage(), request);
     }
 
+    @ExceptionHandler(SlaPolicyNotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handleSlaPolicyNotFound(
+            SlaPolicyNotFoundException ex, HttpServletRequest request) {
+        return buildResponse(HttpStatus.NOT_FOUND, "Not Found", ex.getMessage(), request);
+    }
+
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<Map<String, Object>> handleBadRequest(
             BadRequestException ex, HttpServletRequest request) {

--- a/backend/src/main/java/com/servicehub/exception/SlaPolicyNotFoundException.java
+++ b/backend/src/main/java/com/servicehub/exception/SlaPolicyNotFoundException.java
@@ -1,0 +1,17 @@
+package com.servicehub.exception;
+
+/**
+ * Exception thrown when an SLA policy is not found.
+ * Extends ResourceNotFoundException for consistent error handling.
+ */
+public class SlaPolicyNotFoundException extends ResourceNotFoundException {
+    
+    public SlaPolicyNotFoundException(String message) {
+        super(message);
+    }
+    
+    public SlaPolicyNotFoundException(String resourceName, String fieldName, Object fieldValue) {
+        super(resourceName, fieldName, fieldValue);
+    }
+}
+

--- a/backend/src/main/java/com/servicehub/model/SlaPolicy.java
+++ b/backend/src/main/java/com/servicehub/model/SlaPolicy.java
@@ -5,7 +5,20 @@ import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
 
-@Entity @Table(name = "sla_policies")
+/**
+ * SLA Policy entity representing time-based targets for service requests.
+ * Each policy is uniquely defined by a combination of Category and Priority.
+ */
+@Entity
+@Table(
+    name = "sla_policies",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_sla_policy_category_priority",
+            columnNames = {"category_id", "priority"}
+        )
+    }
+)
 @Data @NoArgsConstructor @AllArgsConstructor @Builder
 public class SlaPolicy {
 
@@ -20,11 +33,11 @@ public class SlaPolicy {
     @Column(nullable = false)
     private Priority priority;
 
-    @Column(name = "response_time_minutes", nullable = false)
-    private Integer responseTimeMinutes;
+    @Column(name = "response_time_hours", nullable = false)
+    private Integer responseTimeHours;
 
-    @Column(name = "resolution_time_minutes", nullable = false)
-    private Integer resolutionTimeMinutes;
+    @Column(name = "resolution_time_hours", nullable = false)
+    private Integer resolutionTimeHours;
 
     @Column(name = "is_active", nullable = false)
     @Builder.Default

--- a/backend/src/main/java/com/servicehub/repository/SlaPolicyRepository.java
+++ b/backend/src/main/java/com/servicehub/repository/SlaPolicyRepository.java
@@ -1,10 +1,30 @@
 package com.servicehub.repository;
 
+import com.servicehub.model.Category;
 import com.servicehub.model.SlaPolicy;
 import com.servicehub.model.enums.Priority;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
 import java.util.Optional;
 
+@Repository
 public interface SlaPolicyRepository extends JpaRepository<SlaPolicy, Integer> {
+    /**
+     * Finds an SLA policy by category and priority.
+     *
+     * @param category the category entity
+     * @param priority the priority enum value
+     * @return Optional containing the policy if found
+     */
+    Optional<SlaPolicy> findByCategoryAndPriority(Category category, Priority priority);
+    
+    /**
+     * Finds an SLA policy by category ID and priority (for backward compatibility).
+     *
+     * @param categoryId the category ID
+     * @param priority the priority enum value
+     * @return Optional containing the policy if found
+     */
     Optional<SlaPolicy> findByCategoryIdAndPriority(Long categoryId, Priority priority);
 }

--- a/backend/src/main/java/com/servicehub/service/SlaPolicyService.java
+++ b/backend/src/main/java/com/servicehub/service/SlaPolicyService.java
@@ -1,11 +1,12 @@
 package com.servicehub.service;
 
-import com.servicehub.dto.request.CreateSlaPolicyRequest;
+import com.servicehub.dto.request.SlaPolicyRequest;
 import com.servicehub.dto.request.UpdateSlaPolicyRequest;
 import com.servicehub.dto.response.SlaPolicyResponse;
 import com.servicehub.exception.BadRequestException;
 import com.servicehub.exception.DuplicateResourceException;
 import com.servicehub.exception.ResourceNotFoundException;
+import com.servicehub.exception.SlaPolicyNotFoundException;
 import com.servicehub.model.Category;
 import com.servicehub.model.SlaPolicy;
 import com.servicehub.model.enums.Priority;
@@ -19,6 +20,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Service for managing SLA policies.
+ * Handles CRUD operations and policy lookups for service request SLA calculations.
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -27,6 +32,11 @@ public class SlaPolicyService {
     private final SlaPolicyRepository slaPolicyRepository;
     private final CategoryRepository categoryRepository;
 
+    /**
+     * Retrieves all SLA policies.
+     *
+     * @return list of all SLA policies
+     */
     @Transactional(readOnly = true)
     public List<SlaPolicyResponse> getAllPolicies() {
         return slaPolicyRepository.findAll().stream()
@@ -34,15 +44,37 @@ public class SlaPolicyService {
                 .collect(Collectors.toList());
     }
 
-    @Transactional
-    public SlaPolicyResponse createPolicy(CreateSlaPolicyRequest request) {
-        Category category = categoryRepository.findById(request.getCategoryId())
-                .orElseThrow(() -> new ResourceNotFoundException("Category not found with id: " + request.getCategoryId()));
+    /**
+     * Retrieves an SLA policy by ID.
+     *
+     * @param id the policy ID
+     * @return the SLA policy response
+     * @throws SlaPolicyNotFoundException if policy not found
+     */
+    @Transactional(readOnly = true)
+    public SlaPolicyResponse getPolicyById(Integer id) {
+        SlaPolicy policy = slaPolicyRepository.findById(id)
+                .orElseThrow(() -> new SlaPolicyNotFoundException("SLA policy not found with id: " + id));
+        return toResponse(policy);
+    }
 
-        Priority priority = Priority.valueOf(request.getPriority().toUpperCase());
+    /**
+     * Creates a new SLA policy.
+     *
+     * @param request the policy creation request
+     * @return the created policy response
+     * @throws DuplicateResourceException if a policy already exists for the category+priority combination
+     * @throws BadRequestException if resolution time is less than response time
+     */
+    @Transactional
+    public SlaPolicyResponse createPolicy(SlaPolicyRequest request) {
+        Category category = categoryRepository.findById(request.categoryId())
+                .orElseThrow(() -> new ResourceNotFoundException("Category not found with id: " + request.categoryId()));
+
+        Priority priority = Priority.valueOf(request.priority().toUpperCase());
 
         // Check no existing active policy for same category + priority
-        slaPolicyRepository.findByCategoryIdAndPriority(request.getCategoryId(), priority)
+        slaPolicyRepository.findByCategoryAndPriority(category, priority)
                 .ifPresent(existing -> {
                     if (existing.getIsActive()) {
                         throw new DuplicateResourceException(
@@ -51,15 +83,15 @@ public class SlaPolicyService {
                     }
                 });
 
-        if (request.getResolutionTimeMinutes() < request.getResponseTimeMinutes()) {
+        if (request.resolutionTimeHours() < request.responseTimeHours()) {
             throw new BadRequestException("Resolution time must be greater than or equal to response time");
         }
 
         SlaPolicy policy = SlaPolicy.builder()
                 .category(category)
                 .priority(priority)
-                .responseTimeMinutes(request.getResponseTimeMinutes())
-                .resolutionTimeMinutes(request.getResolutionTimeMinutes())
+                .responseTimeHours(request.responseTimeHours())
+                .resolutionTimeHours(request.resolutionTimeHours())
                 .isActive(true)
                 .build();
 
@@ -68,23 +100,32 @@ public class SlaPolicyService {
         return toResponse(policy);
     }
 
+    /**
+     * Updates an existing SLA policy.
+     *
+     * @param id the policy ID
+     * @param request the update request
+     * @return the updated policy response
+     * @throws SlaPolicyNotFoundException if policy not found
+     * @throws BadRequestException if resolution time is less than response time
+     */
     @Transactional
     public SlaPolicyResponse updatePolicy(Integer id, UpdateSlaPolicyRequest request) {
         SlaPolicy policy = slaPolicyRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("SLA policy not found with id: " + id));
+                .orElseThrow(() -> new SlaPolicyNotFoundException("SLA policy not found with id: " + id));
 
-        if (request.getResponseTimeMinutes() != null) {
-            policy.setResponseTimeMinutes(request.getResponseTimeMinutes());
+        if (request.responseTimeHours() != null) {
+            policy.setResponseTimeHours(request.responseTimeHours());
         }
-        if (request.getResolutionTimeMinutes() != null) {
-            policy.setResolutionTimeMinutes(request.getResolutionTimeMinutes());
+        if (request.resolutionTimeHours() != null) {
+            policy.setResolutionTimeHours(request.resolutionTimeHours());
         }
-        if (request.getIsActive() != null) {
-            policy.setIsActive(request.getIsActive());
+        if (request.isActive() != null) {
+            policy.setIsActive(request.isActive());
         }
 
         // Validate resolution >= response if both are set
-        if (policy.getResolutionTimeMinutes() < policy.getResponseTimeMinutes()) {
+        if (policy.getResolutionTimeHours() < policy.getResponseTimeHours()) {
             throw new BadRequestException("Resolution time must be greater than or equal to response time");
         }
 
@@ -93,15 +134,53 @@ public class SlaPolicyService {
         return toResponse(policy);
     }
 
-    private SlaPolicyResponse toResponse(SlaPolicy p) {
-        return SlaPolicyResponse.builder()
-                .id(p.getId())
-                .categoryId(p.getCategory().getId())
-                .categoryName(p.getCategory().getName())
-                .priority(p.getPriority().name())
-                .responseTimeMinutes(p.getResponseTimeMinutes())
-                .resolutionTimeMinutes(p.getResolutionTimeMinutes())
-                .isActive(p.getIsActive())
-                .build();
+    /**
+     * Deletes an SLA policy.
+     *
+     * @param id the policy ID
+     * @throws SlaPolicyNotFoundException if policy not found
+     */
+    @Transactional
+    public void deletePolicy(Integer id) {
+        SlaPolicy policy = slaPolicyRepository.findById(id)
+                .orElseThrow(() -> new SlaPolicyNotFoundException("SLA policy not found with id: " + id));
+        slaPolicyRepository.delete(policy);
+        log.info("SLA policy {} deleted", id);
+    }
+
+    /**
+     * Looks up SLA policy target times for a given category and priority.
+     * Used by service request creation to determine SLA deadlines.
+     *
+     * @param category the category entity
+     * @param priority the priority enum value
+     * @return the SLA policy with target times
+     * @throws SlaPolicyNotFoundException if no active policy exists for the category+priority combination
+     */
+    @Transactional(readOnly = true)
+    public SlaPolicy getTargetTimes(Category category, Priority priority) {
+        return slaPolicyRepository.findByCategoryAndPriority(category, priority)
+                .filter(SlaPolicy::getIsActive)
+                .orElseThrow(() -> new SlaPolicyNotFoundException(
+                        String.format("No active SLA policy found for category '%s' with priority '%s'",
+                                category.getName(), priority)));
+    }
+
+    /**
+     * Converts an SlaPolicy entity to a SlaPolicyResponse DTO.
+     *
+     * @param policy the entity
+     * @return the response DTO
+     */
+    private SlaPolicyResponse toResponse(SlaPolicy policy) {
+        return new SlaPolicyResponse(
+                policy.getId(),
+                policy.getCategory().getId(),
+                policy.getCategory().getName(),
+                policy.getPriority().name(),
+                policy.getResponseTimeHours(),
+                policy.getResolutionTimeHours(),
+                policy.getIsActive()
+        );
     }
 }


### PR DESCRIPTION
- Update SlaPolicy entity to use hours instead of minutes with unique constraint on category+priority
- Add findByCategoryAndPriority method to SlaPolicyRepository
- Convert DTOs to Java Records (SlaPolicyRequest, UpdateSlaPolicyRequest, SlaPolicyResponse)
- Implement getTargetTimes lookup method in SlaPolicyService for SLA deadline calculations
- Add CRUD operations with proper transactional boundaries
- Update SlaPolicyController to /api/v1/sla-policies with role-based authorization
- Create SlaPolicyNotFoundException with proper exception handling
- Ensure ADMIN-only access for create/update/delete, authenticated access for read