### PR TITLE
feat(sla): implement tracking service for response and resolution timers

### DIFF
--- a/backend/src/main/java/com/servicehub/model/ServiceRequest.java
+++ b/backend/src/main/java/com/servicehub/model/ServiceRequest.java
@@ -50,11 +50,11 @@ public class ServiceRequest {
     @JoinColumn(name = "assigned_agent_id")
     private User assignedAgent;
 
-    @Column(name = "response_sla_deadline")
-    private LocalDateTime responseSlaDeadline;
+    @Column(name = "response_due_at")
+    private LocalDateTime responseDueAt;
 
-    @Column(name = "resolution_sla_deadline")
-    private LocalDateTime resolutionSlaDeadline;
+    @Column(name = "resolution_due_at")
+    private LocalDateTime resolutionDueAt;
 
     @Column(name = "response_sla_met")
     private Boolean responseSlaMet;
@@ -67,6 +67,10 @@ public class ServiceRequest {
 
     @Column(name = "resolved_at")
     private LocalDateTime resolvedAt;
+
+    @Column(name = "is_sla_breached", nullable = false)
+    @Builder.Default
+    private Boolean isSlaBreached = false;
 
     @Column(name = "closed_at")
     private LocalDateTime closedAt;

--- a/backend/src/main/java/com/servicehub/service/RequestWorkflowService.java
+++ b/backend/src/main/java/com/servicehub/service/RequestWorkflowService.java
@@ -31,6 +31,8 @@ public class RequestWorkflowService {
 
     private final ServiceRequestRepository serviceRequestRepository;
     private final StatusHistoryRepository statusHistoryRepository;
+    private final StatusHistoryService statusHistoryService;
+    private final SlaTrackingService slaTrackingService;
     private final UserRepository userRepository;
     private final StatusTransitionValidator statusTransitionValidator;
 
@@ -73,10 +75,26 @@ public class RequestWorkflowService {
         // Update the request status
         String previousStatus = currentStatus.name();
         request.setStatus(newStatus);
-        LocalDateTime now = LocalDateTime.now();
 
         // Handle SLA tracking based on status changes
-        updateSlaTracking(request, newStatus, now);
+        if (newStatus == RequestStatus.ASSIGNED) {
+            // Record response when ticket is assigned
+            slaTrackingService.recordResponse(request);
+        } else if (newStatus == RequestStatus.RESOLVED) {
+            // Record resolution when ticket is resolved
+            slaTrackingService.recordResolution(request);
+        } else if (newStatus == RequestStatus.CLOSED) {
+            // Record closed timestamp
+            request.setClosedAt(LocalDateTime.now());
+        } else if (newStatus == RequestStatus.OPEN && currentStatus == RequestStatus.RESOLVED) {
+            // Reopening: reset SLA tracking timestamps
+            request.setResolvedAt(null);
+            request.setResolutionSlaMet(null);
+            request.setResponseSlaMet(null);
+            request.setRespondedAt(null);
+            request.setIsSlaBreached(false);
+            // Note: Due dates remain unchanged on reopen
+        }
 
         // Save the updated request
         ServiceRequest savedRequest = serviceRequestRepository.save(request);
@@ -105,46 +123,6 @@ public class RequestWorkflowService {
                 comment,
                 savedHistory.getChangedAt()
         );
-    }
-
-    /**
-     * Updates SLA tracking fields based on status changes.
-     *
-     * @param request   the service request
-     * @param newStatus the new status
-     * @param now       the current timestamp
-     */
-    private void updateSlaTracking(ServiceRequest request, RequestStatus newStatus, LocalDateTime now) {
-        // When status moves to IN_PROGRESS, mark response SLA
-        if (newStatus == RequestStatus.IN_PROGRESS && request.getRespondedAt() == null) {
-            request.setRespondedAt(now);
-            if (request.getResponseSlaDeadline() != null) {
-                request.setResponseSlaMet(now.isBefore(request.getResponseSlaDeadline()));
-            }
-        }
-
-        // When status moves to RESOLVED, mark resolution SLA
-        if (newStatus == RequestStatus.RESOLVED) {
-            request.setResolvedAt(now);
-            if (request.getResolutionSlaDeadline() != null) {
-                request.setResolutionSlaMet(now.isBefore(request.getResolutionSlaDeadline()));
-            }
-        }
-
-        // When status moves to CLOSED, record closed timestamp
-        if (newStatus == RequestStatus.CLOSED) {
-            request.setClosedAt(now);
-        }
-
-        // If reopening (RESOLVED -> OPEN), reset SLA tracking
-        if (newStatus == RequestStatus.OPEN && request.getResolvedAt() != null) {
-            request.setResolvedAt(null);
-            request.setResolutionSlaMet(null);
-            request.setResponseSlaMet(null);
-            request.setRespondedAt(null);
-            // Note: SLA deadlines would need to be recalculated by the SLA service
-            // This is handled in the main ServiceRequestService for now
-        }
     }
 }
 

--- a/backend/src/main/java/com/servicehub/service/ServiceRequestService.java
+++ b/backend/src/main/java/com/servicehub/service/ServiceRequestService.java
@@ -42,6 +42,7 @@ public class ServiceRequestService {
     private final UserRepository userRepository;
     private final SlaPolicyRepository slaPolicyRepository;
     private final StatusHistoryRepository statusHistoryRepository;
+    private final SlaTrackingService slaTrackingService;
     private final LocationRepository locationRepository;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -83,17 +84,17 @@ public class ServiceRequestService {
                 .location(requester.getLocation())
                 .requester(requester)
                 .isDeleted(false)
+                .isSlaBreached(false)
                 .build();
 
-        // Look up SLA policy and compute deadlines
-        slaPolicyRepository.findByCategoryIdAndPriority(category.getId(), priority)
-                .ifPresent(sla -> {
-                    LocalDateTime now = LocalDateTime.now();
-                    request.setResponseSlaDeadline(now.plusMinutes(sla.getResponseTimeMinutes()));
-                    request.setResolutionSlaDeadline(now.plusMinutes(sla.getResolutionTimeMinutes()));
-                });
-
+        // Save request first to get created_at timestamp
         ServiceRequest savedRequest = serviceRequestRepository.save(request);
+
+        // Initialize SLA tracking using SlaTrackingService
+        slaTrackingService.initializeSla(savedRequest);
+        
+        // Save again to persist SLA due dates
+        savedRequest = serviceRequestRepository.save(savedRequest);
 
         // Create initial status history entry
         StatusHistory initialHistory = StatusHistory.builder()
@@ -377,6 +378,10 @@ public class ServiceRequestService {
             request.setStatus(RequestStatus.ASSIGNED);
             serviceRequestRepository.save(request);
 
+            // Record response SLA when auto-assigned
+            slaTrackingService.recordResponse(request);
+            serviceRequestRepository.save(request);
+
             StatusHistory assignHistory = StatusHistory.builder()
                     .request(request)
                     .fromStatus(RequestStatus.OPEN.name())
@@ -422,8 +427,8 @@ public class ServiceRequestService {
                 .requesterId(r.getRequester() != null ? r.getRequester().getId() : null)
                 .assignedAgentName(r.getAssignedAgent() != null ? r.getAssignedAgent().getFullName() : null)
                 .assignedAgentId(r.getAssignedAgent() != null ? r.getAssignedAgent().getId() : null)
-                .responseSlaDeadline(r.getResponseSlaDeadline())
-                .resolutionSlaDeadline(r.getResolutionSlaDeadline())
+                .responseSlaDeadline(r.getResponseDueAt())
+                .resolutionSlaDeadline(r.getResolutionDueAt())
                 .responseSlaMet(r.getResponseSlaMet())
                 .resolutionSlaMet(r.getResolutionSlaMet())
                 .respondedAt(r.getRespondedAt())

--- a/backend/src/main/java/com/servicehub/service/SlaTrackingService.java
+++ b/backend/src/main/java/com/servicehub/service/SlaTrackingService.java
@@ -1,0 +1,157 @@
+package com.servicehub.service;
+
+import com.servicehub.exception.SlaPolicyNotFoundException;
+import com.servicehub.model.Category;
+import com.servicehub.model.SlaPolicy;
+import com.servicehub.model.ServiceRequest;
+import com.servicehub.model.enums.Priority;
+import com.servicehub.repository.SlaPolicyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * Service for tracking SLA deadlines and compliance.
+ * Handles initialization of SLA due dates and recording of response/resolution timestamps.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SlaTrackingService {
+
+    private final SlaPolicyRepository slaPolicyRepository;
+    private final SlaPolicyService slaPolicyService;
+
+    /**
+     * Initializes SLA tracking for a newly created service request.
+     * Fetches the SLA policy for the request's category and priority,
+     * then calculates response and resolution due dates.
+     *
+     * @param request the service request to initialize SLA for
+     * @throws SlaPolicyNotFoundException if no active SLA policy exists for the category+priority combination
+     */
+    @Transactional
+    public void initializeSla(ServiceRequest request) {
+        Category category = request.getCategory();
+        Priority priority = request.getPriority();
+        LocalDateTime createdAt = request.getCreatedAt() != null 
+                ? request.getCreatedAt() 
+                : LocalDateTime.now();
+
+        try {
+            // Fetch the SLA policy using the service lookup method
+            SlaPolicy policy = slaPolicyService.getTargetTimes(category, priority);
+
+            // Calculate due dates based on hours from creation time
+            LocalDateTime responseDueAt = createdAt.plusHours(policy.getResponseTimeHours());
+            LocalDateTime resolutionDueAt = createdAt.plusHours(policy.getResolutionTimeHours());
+
+            // Set the due dates on the request
+            request.setResponseDueAt(responseDueAt);
+            request.setResolutionDueAt(resolutionDueAt);
+            request.setIsSlaBreached(false); // Initialize as not breached
+
+            log.debug("SLA initialized for request {}: response due at {}, resolution due at {}",
+                    request.getReferenceNumber(), responseDueAt, resolutionDueAt);
+        } catch (SlaPolicyNotFoundException e) {
+            log.warn("No SLA policy found for category {} with priority {}. SLA tracking will not be initialized for request {}",
+                    category.getName(), priority, request.getReferenceNumber());
+            // Set due dates to null to indicate no SLA policy exists
+            request.setResponseDueAt(null);
+            request.setResolutionDueAt(null);
+            request.setIsSlaBreached(false);
+            // Note: We don't throw here to allow request creation even without SLA policy
+            // The business logic can decide if this should be a hard requirement
+        }
+    }
+
+    /**
+     * Records the response timestamp when a ticket is assigned.
+     * Sets responded_at to the current time and checks if the response SLA was met.
+     *
+     * @param request the service request being assigned
+     */
+    @Transactional
+    public void recordResponse(ServiceRequest request) {
+        // Only record if not already recorded
+        if (request.getRespondedAt() != null) {
+            log.debug("Response already recorded for request {}", request.getReferenceNumber());
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        request.setRespondedAt(now);
+
+        // Check if response SLA was met
+        if (request.getResponseDueAt() != null) {
+            boolean responseSlaMet = now.isBefore(request.getResponseDueAt()) || now.isEqual(request.getResponseDueAt());
+            request.setResponseSlaMet(responseSlaMet);
+
+            if (!responseSlaMet) {
+                log.warn("Response SLA breached for request {}: responded at {} but due at {}",
+                        request.getReferenceNumber(), now, request.getResponseDueAt());
+                // Update breach flag if response was missed
+                request.setIsSlaBreached(true);
+            } else {
+                log.debug("Response SLA met for request {}: responded at {} (due at {})",
+                        request.getReferenceNumber(), now, request.getResponseDueAt());
+            }
+        } else {
+            // No SLA policy, so we can't determine if SLA was met
+            request.setResponseSlaMet(null);
+            log.debug("No response SLA deadline set for request {}", request.getReferenceNumber());
+        }
+    }
+
+    /**
+     * Records the resolution timestamp when a ticket is resolved.
+     * Sets resolved_at to the current time, checks if the resolution SLA was met,
+     * and finalizes the is_sla_breached flag.
+     *
+     * @param request the service request being resolved
+     */
+    @Transactional
+    public void recordResolution(ServiceRequest request) {
+        // Only record if not already recorded
+        if (request.getResolvedAt() != null) {
+            log.debug("Resolution already recorded for request {}", request.getReferenceNumber());
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        request.setResolvedAt(now);
+
+        // Check if resolution SLA was met
+        if (request.getResolutionDueAt() != null) {
+            boolean resolutionSlaMet = now.isBefore(request.getResolutionDueAt()) || now.isEqual(request.getResolutionDueAt());
+            request.setResolutionSlaMet(resolutionSlaMet);
+
+            if (!resolutionSlaMet) {
+                log.warn("Resolution SLA breached for request {}: resolved at {} but due at {}",
+                        request.getReferenceNumber(), now, request.getResolutionDueAt());
+            } else {
+                log.debug("Resolution SLA met for request {}: resolved at {} (due at {})",
+                        request.getReferenceNumber(), now, request.getResolutionDueAt());
+            }
+        } else {
+            // No SLA policy, so we can't determine if SLA was met
+            request.setResolutionSlaMet(null);
+            log.debug("No resolution SLA deadline set for request {}", request.getReferenceNumber());
+        }
+
+        // Finalize the breach flag: true if either response or resolution SLA was missed
+        boolean isBreached = Boolean.TRUE.equals(request.getIsSlaBreached()) 
+                || (request.getResponseSlaMet() != null && !request.getResponseSlaMet())
+                || (request.getResolutionSlaMet() != null && !request.getResolutionSlaMet());
+        request.setIsSlaBreached(isBreached);
+
+        if (isBreached) {
+            log.warn("SLA breach finalized for request {}: responseSlaMet={}, resolutionSlaMet={}",
+                    request.getReferenceNumber(), request.getResponseSlaMet(), request.getResolutionSlaMet());
+        }
+    }
+}
+


### PR DESCRIPTION
- Create SlaTrackingService with initializeSla, recordResponse, and recordResolution methods
- Update ServiceRequest entity with response_due_at, resolution_due_at, and is_sla_breached fields
- Integrate SlaTrackingService into RequestWorkflowService for status transition tracking
- Update ServiceRequestService to initialize SLA on ticket creation
- Handle missing SLA policy gracefully (logs warning, allows request creation)
- Record response SLA when ticket transitions to ASSIGNED
- Record resolution SLA when ticket transitions to RESOLVED
- Finalize is_sla_breached flag based on response and resolution compliance
- Update auto-assignment to record response SLA immediately